### PR TITLE
Update line 816 of URIUtility.cs

### DIFF
--- a/URIUtility/PeterO/URIUtility.cs
+++ b/URIUtility/PeterO/URIUtility.cs
@@ -813,7 +813,7 @@ namespace PeterO {
     s,
     0,
     s.Length,
-    mode)) != null;
+    parseMode)) != null;
     }
 
     private const string ValueDotSlash = "." + "/";


### PR DESCRIPTION
The variable mode does not exist, should it have been named as parseMode?